### PR TITLE
Adicionado o Okular como leitor de PDF padrão

### DIFF
--- a/usr/share/bigbashview/bcc/apps/bigbashview-calamares/desktops/lxqt/pkginstall.txt
+++ b/usr/share/bigbashview/bcc/apps/bigbashview-calamares/desktops/lxqt/pkginstall.txt
@@ -46,3 +46,4 @@ brave-browser
 kate
 kcalc
 telegram-desktop
+okular


### PR DESCRIPTION
Okular é um visualizador de arquivos PDF e outros formatos de documentos para o sistema operacional Linux. Ele é desenvolvido pelo KDE (Comunidade de Desenvolvimento de Desktop do KDE). Além de visualizar arquivos PDF, o Okular também permite realizar anotações, destacar trechos, adicionar notas, inserir imagens e outras marcações nos documentos. Outras funcionalidades incluem busca de palavras, rotação de páginas, zoom e modo de exibição em tela cheia.